### PR TITLE
Fix "Want to Contribute?" link in footer.

### DIFF
--- a/_includes/footer.md
+++ b/_includes/footer.md
@@ -2,7 +2,7 @@
 
 Mockito is [open source]({{ site.source_link }})
 &mdash;
-Want to [contribute?](https://github.com/mockito/mockito/wiki/How%20To%20Contribute)
+Want to [contribute?](https://github.com/mockito/mockito/blob/master/CONTRIBUTING.md)
 &mdash;
 Issue [tracker](https://github.com/mockito/mockito/issues)
 &mdash;


### PR DESCRIPTION
Previous link was to a missing Github Wiki page.
