### PR TITLE
Fix link "Contribute" in links section

### DIFF
--- a/_posts/2000-01-25-links.md
+++ b/_posts/2000-01-25-links.md
@@ -8,7 +8,7 @@ fa-icon: link
 
 ### Wiki
 * [FAQ](https://github.com/mockito/mockito/wiki/FAQ)
-* [How to contribute](https://github.com/mockito/mockito/wiki/How%20To%20Contribute)
+* [How to contribute](https://github.com/mockito/mockito/blob/master/CONTRIBUTING.md)
 * [Mockito for python](https://code.google.com/p/mockito/wiki/MockitoForPython)
 * [Mockito VS EasyMock](https://code.google.com/p/mockito/wiki/MockitoVSEasyMock)
 * [Related projects](https://code.google.com/p/mockito/wiki/RelatedProjects)


### PR DESCRIPTION
Previous link headed to an empty wiki page
