### PR TITLE
Fix obsolete, broken links to Google Code

### DIFF
--- a/_posts/2000-01-02-why.md
+++ b/_posts/2000-01-02-why.md
@@ -9,7 +9,7 @@ fa-icon: glass
 Mockito is a mocking framework that tastes really good.
 It lets you write beautiful tests with clean & simple API.
 Mockito doesn't give you hangover because the tests are very readable and they produce clean verification errors.
-Read more about [features & motivations](https://code.google.com/p/mockito/wiki/FeaturesAndMotivations).
+Read more about [features & motivations](https://github.com/mockito/mockito/wiki/Features-And-Motivations).
 
 * Massive StackOverflow community voted Mockito the best mocking framework for java.
 Even though StackOverflow shuns questions that likely raise emotional debates the fact is

--- a/_posts/2000-01-25-links.md
+++ b/_posts/2000-01-25-links.md
@@ -9,9 +9,9 @@ fa-icon: link
 ### Wiki
 * [FAQ](https://github.com/mockito/mockito/wiki/FAQ)
 * [How to contribute](https://github.com/mockito/mockito/blob/master/CONTRIBUTING.md)
-* [Mockito for python](https://code.google.com/p/mockito/wiki/MockitoForPython)
-* [Mockito VS EasyMock](https://code.google.com/p/mockito/wiki/MockitoVSEasyMock)
-* [Related projects](https://code.google.com/p/mockito/wiki/RelatedProjects)
+* [Mockito for python](https://github.com/mockito/mockito/wiki/Mockito-for-Python)
+* [Mockito VS EasyMock](https://github.com/mockito/mockito/wiki/Mockito-vs-EasyMock)
+* [Related projects](https://github.com/mockito/mockito/wiki/Related-Projects)
 * [Release notes](https://github.com/mockito/mockito/blob/master/doc/release-notes/official.md)
 * [More wiki pages](https://github.com/mockito/mockito/wiki)
 * [Old wiki pages on google code](https://code.google.com/p/mockito/w/list)


### PR DESCRIPTION
Replaced the links with ones pointing to the wiki on GitHub.

As I've just started looking into the Mockito project for the first time, it's pretty shitty to hit a 404 on literally the first link I clicked on ("features & motivations"). I searched and fixed a few other similar obsolete links.
