### PR TITLE
Update Contribute Link

### DIFF
--- a/_posts/2000-01-01-intro.md
+++ b/_posts/2000-01-01-intro.md
@@ -34,7 +34,7 @@ See the [release notes page](https://github.com/mockito/mockito/blob/master/doc/
 Fancy getting world-wide visibility and building up an eternal fame of an OSS contributor?
 
 * Help the [project site](https://github.com/mockito/mockito.github.io) look decent and match the quality of the library!
-* [Contribute](https://github.com/mockito/mockito/wiki/How%20To%20Contribute) a pull request! It is automatically released via state-of-art [continuous delivery automation](http://szczepiq.blogspot.com/2014_08_01_archive.html).
+* [Contribute](https://github.com/mockito/mockito/blob/master/.github/CONTRIBUTING.md) a pull request! It is automatically released via state-of-art [continuous delivery automation](http://szczepiq.blogspot.com/2014_08_01_archive.html).
 * Use latest version! Hack and experiment. Speak up at the [mailing list](http://groups.google.com/group/mockito). Report [issues and new features](https://github.com/mockito/mockito/issues).
 
 <span id="forkongithub">


### PR DESCRIPTION
Mockito's contributor's guide is placed to [mockito/.github/CONTRIBUTING.md](https://github.com/mockito/mockito/blob/master/.github/CONTRIBUTING.md)

In the [Mockito wiki](https://github.com/mockito/mockito/wiki) contribution link ~~is~~ was broken as well.

https://github.com/mockito/mockito.github.io/issues/11
