### PR TITLE
Updated Bintray download badge

### DIFF
--- a/_posts/2000-01-01-intro.md
+++ b/_posts/2000-01-01-intro.md
@@ -14,7 +14,7 @@ style: center
 [![Coverage Status](https://img.shields.io/codecov/c/github/mockito/mockito.svg)](https://codecov.io/github/mockito/mockito)
 [![MIT License](http://img.shields.io/badge/license-MIT-green.svg)](https://github.com/mockito/mockito/blob/master/LICENSE)
 
-[![Latest 2.x on bintray](https://api.bintray.com/packages/mockito/maven/mockito/images/download.svg)](https://bintray.com/mockito/maven/mockito/_latestVersion)
+[![Latest 2.x on bintray](https://api.bintray.com/packages/mockito/maven/mockito-development/images/download.svg)](https://bintray.com/mockito/maven/mockito-development/_latestVersion)
 [![Latest 2.x on Maven Central](https://maven-badges.herokuapp.com/maven-central/org.mockito/mockito-core/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/org.mockito/mockito-core)
 
 </div>


### PR DESCRIPTION
We should show 2 downloads: notable relases (central - we got it in a different badge) and incremental/development releases (we will have it when this is merged :)