### PR TITLE
Updated download shields

### DIFF
--- a/_posts/2000-01-01-intro.md
+++ b/_posts/2000-01-01-intro.md
@@ -14,7 +14,7 @@ style: center
 [![Coverage Status](https://img.shields.io/codecov/c/github/mockito/mockito.svg)](https://codecov.io/github/mockito/mockito)
 [![MIT License](http://img.shields.io/badge/license-MIT-green.svg)](https://github.com/mockito/mockito/blob/master/LICENSE)
 
-[![Bintray](https://img.shields.io/bintray/v/mockito/maven/mockito-development.svg)](https://bintray.com/mockito/maven)
+[![Bintray](https://api.bintray.com/packages/mockito/maven/mockito-development/images/download.svg)](https://bintray.com/mockito/maven)
 [![Maven Central](https://img.shields.io/maven-central/v/org.mockito/mockito-core.svg)](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.8.47%7C)
 
 </div>

--- a/_posts/2000-01-01-intro.md
+++ b/_posts/2000-01-01-intro.md
@@ -14,8 +14,8 @@ style: center
 [![Coverage Status](https://img.shields.io/codecov/c/github/mockito/mockito.svg)](https://codecov.io/github/mockito/mockito)
 [![MIT License](http://img.shields.io/badge/license-MIT-green.svg)](https://github.com/mockito/mockito/blob/master/LICENSE)
 
-[![Latest 2.x on bintray](https://api.bintray.com/packages/mockito/maven/mockito-development/images/download.svg)](https://bintray.com/mockito/maven/mockito-development/_latestVersion)
-[![Latest 2.x on Maven Central](https://maven-badges.herokuapp.com/maven-central/org.mockito/mockito-core/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/org.mockito/mockito-core)
+[![Bintray](https://img.shields.io/bintray/v/mockito/maven/mockito-development.svg)](https://bintray.com/mockito/maven)
+[![Maven Central](https://img.shields.io/maven-central/v/org.mockito/mockito-core.svg)](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.8.47%7C)
 
 </div>
 


### PR DESCRIPTION
- tidy up, made the repository explicit
- made the Maven central link go directly to central

Consistent with what we have in README.md of Mockito