### PR TITLE
Update dexmaker reference to use more neutral language

### DIFF
--- a/_posts/2000-01-15-more.md
+++ b/_posts/2000-01-15-more.md
@@ -19,7 +19,7 @@ fa-icon: book
     * can use flexible argument matching, for example any expression via the [`any()`](http://javadoc.io/page/org.mockito/mockito-core/latest/org/mockito/Matchers.html#any())
     * or capture what arguments were called using [`@Captor`](http://javadoc.io/page/org.mockito/mockito-core/latest/org/mockito/Captor.html) instead
 * Try Behavior-Driven development syntax with [BDDMockito](http://javadoc.io/page/org.mockito/mockito-core/latest/org/mockito/BDDMockito.html)
-* Use Mockito on Android, thanks to the Google guys working on [dexmaker](https://github.com/crittercism/dexmaker)
+* Use Mockito on Android, thanks to the team working on [dexmaker](https://github.com/crittercism/dexmaker)
 
 ## Remember
 


### PR DESCRIPTION
Removing "guys" as it's a gender neutral term. 

Also removed Google as it isn't clear it is a Google team doing the work; example given points to LinkedIn. 

In any case, it doesn't add anything of value to reference "Google guys"