### PR TITLE
Edit twitter url and bintray url

### DIFF
--- a/_posts/2000-01-20-who.md
+++ b/_posts/2000-01-20-who.md
@@ -4,7 +4,7 @@ color: black
 fa-icon: trophy
 ---
 
-Mockito is served to you by **[Szczepan Faber](https://twitter.com/szczepiq) and friends**.
+Mockito is served to you by **[Szczepan Faber](https://twitter.com/mockitoguy) and friends**.
 First engineers who were using Mockito in production were developers of the
 [Guardian](http://guardian.co.uk/) project in London in early 2008.
 Szczepan was lucky to be a part of the ThoughtWorks team assigned to the challenging and exciting Guardian project.
@@ -13,13 +13,13 @@ Here is how he explained why we needed [another mocking framework](http://monkey
 Hats down before **[EasyMock](http://easymock.org/) folks** for their ideas on beautiful and refactoring-friendly mocking API.
 **First hacks on Mockito were done on top of the EasyMock code.**
 
-Currently Mockito is maintained by [**Szczepan Faber**](https://twitter.com/szczepiq), [**Brice Dutheil**](https://twitter.com/BriceDutheil), [**Rafael Winterhalter**](https://twitter.com/rafaelcodes), [**Tim van der Lippe**](https://twitter.com/TimvdLippe), Marcin Grzejszczak, Marcin Zajączkowski and
+Currently Mockito is maintained by [**Szczepan Faber**](https://twitter.com/mockitoguy), [**Brice Dutheil**](https://twitter.com/BriceDutheil), [**Rafael Winterhalter**](https://twitter.com/rafaelcodes), [**Tim van der Lippe**](https://twitter.com/TimvdLippe), Marcin Grzejszczak, Marcin Zajączkowski and
 a small [army of contributors](https://github.com/mockito/mockito/graphs/contributors).
 Friends who contributed to Mockito (apologize if I missed somebody):
 **Pascal Schumacher**, **Christian Schwartz**, **Igor Czechowski**, **Patric Fornasier**, **Jim Barritt**,
 **Felix Leipold**, **Liz Keogh**, **Dan North**, **Bartosz Bańkowski**, **David Wallace**.
 
-[Travis CI](https://travis-ci.org/mockito/mockito) and [Bintray](https://bintray.com/szczepiq/maven/mockito/view) are used to facilitate continuous delivery.
+[Travis CI](https://travis-ci.org/mockito/mockito) and [Bintray](https://bintray.com/mockito/maven/mockito) are used to facilitate continuous delivery.
 Both tools are great. Thank you Travis, thank you Bintray!
 
 * Thanks to **Éric Lefevre-Ardant** for his long running and continuous support on the mailing-list


### PR DESCRIPTION
Hey just looking into some Mockito and saw that your pages is OSS, awesome!
Made minor changes so that Szczepan Faber's twitter is redirecting to the one in use and the previous Bintray URL was serving a 404 so looked for what I believe is the correct URL.

