### PR TITLE
How to find the manual download page easier.

### DIFF
--- a/_posts/2000-01-10-how.md
+++ b/_posts/2000-01-10-how.md
@@ -19,6 +19,10 @@ Maven users can declare a [dependency on mockito-core](http://search.maven.org/#
 Mockito is automatically published to [Bintray's jcenter](http://jcenter.bintray.com/org/mockito/mockito-core)
 and synced to the Maven Central Repository.
 
+Users doing manual dependency management can download the jars directly from 
+[Mockito's Bintray repository](https://bintray.com/mockito/maven/mockito-development/_latestVersion),
+under the Files tab.
+
 Legacy builds with manual dependency management can use 1.* "mockito-all" distribution.
 It can be downloaded from Mockito's Bintray repository or Bintray's jcenter.
 "mockito-all" distribution has been discontinued in Mockito 2.*.


### PR DESCRIPTION
Given how I got to the page via a closed ("off-topic") StackOverflow question earlier with about 1K views on it, I suspect a bunch of people don't know the Download button at the top of the site is clickable. This spells it out.