### PR TITLE
Fixed the Maven Central link

### DIFF
--- a/_posts/2000-01-10-how.md
+++ b/_posts/2000-01-10-how.md
@@ -15,7 +15,7 @@ repositories { jcenter() }
 dependencies { testCompile "org.mockito:mockito-core:2.+" }
 {% endhighlight %}
 
-Maven users can declare a [dependency on mockito-core](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.mockito%22%2C%20a%3A%22mockito-core%22).
+Maven users can declare a [dependency on mockito-core](https://search.maven.org/search?q=g:org.mockito%20a:mockito-core).
 Mockito is automatically published to [Bintray's jcenter](http://jcenter.bintray.com/org/mockito/mockito-core)
 and synced to the Maven Central Repository.
 


### PR DESCRIPTION
Previous link stopped working.