### PR TITLE
Fixes #47 : Reorganize for 3.x releases, reduce duplication

### DIFF
--- a/_posts/2000-01-01-intro.md
+++ b/_posts/2000-01-01-intro.md
@@ -10,7 +10,7 @@ style: center
 
 <div markdown="1">
 
-[![Build Status](https://travis-ci.org/mockito/mockito.svg?branch=release/2.x)](https://travis-ci.org/mockito/mockito)
+[![Build Status](https://travis-ci.org/mockito/mockito.svg?branch=release/3.x)](https://travis-ci.org/mockito/mockito)
 [![Coverage Status](https://img.shields.io/codecov/c/github/mockito/mockito.svg)](https://codecov.io/github/mockito/mockito)
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/mockito/mockito/blob/master/LICENSE)
 
@@ -24,35 +24,38 @@ style: center
 
 
 
-### Current version is <strong>3</strong>
+### Project status
 
-Still on Mockito 1.x? See [what's new in Mockito 2](https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2)!
+Please see the [release notes page](https://github.com/mockito/mockito/blob/release/3.x/doc/release-notes/official.md).
 
-See the [release notes page](https://github.com/mockito/mockito/blob/release/3.x/doc/release-notes/official.md)
-and [latest documentation](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html)
-(docs in javadoc.io are available 24h after release). 
+Updates are announced via [Twitter](https://twitter.com/mockitojava)
+<a href="https://twitter.com/mockitojava?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">Follow @mockitojava</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+and [mailing list] <img alt="Google Groups" src="https://groups.google.com/forum/favicon.ico" width="21" height="21">.
 
-Older 1.x releases are available in [Central Repository](https://search.maven.org/artifact/org.mockito/mockito-core/1.10.19/jar)
-, [Bintray](https://bintray.com/mockito/maven/mockito/1.10.19/view) and [javadoc.io](https://www.javadoc.io/doc/org.mockito/mockito-core/1.10.19) (documentation).
+Mockito downloads and instructions for setting up Maven, Gradle and other build systems are available from the
+[Central Repository](https://search.maven.org/artifact/org.mockito/mockito-core/) and
+[Bintray](https://bintray.com/mockito/maven/mockito/).
+
+The documentation for all versions is available on
+[javadoc.io](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html)
+(the site is updated within 24 hours of the latest release).
+
+**Still on Mockito 1.x?** See [what's new in Mockito 2](https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2)!
+Mockito 3.x requires Java 8, but otherwise doesn't introduce any breaking changes compared to the 2.x series.
 
 <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=mockitoorg" id="_carbonads_js"></script>
 (<a href="https://github.com/mockito/mockito/wiki/Ads-on-mockito.org-site">why above ad?</a>)
 
-### Project status updates
-
-Updates are announced via [Twitter](https://twitter.com/mockitojava) <img alt="Twitter logo" src="https://g.twimg.com/dev/img/marketing/twitter-for-websites/header-logo.png" width="21" height="21"> and [mailing list] <img alt="Google Groups" src="https://groups.google.com/forum/favicon.ico" width="21" height="21">.
-
-After releasing Mockito 2 (<a href="https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2">see what's new</a>) the team will continue to improve version 2.x for a short time, then focus on Mockito 3.
-Please provide your feedback and suggestions for the scope of Mockito 3.x using the above two channels and <a href="https://github.com/mockito/mockito/issues">GitHub issue tracker</a>.
-Mockito 3.x will target Java 8.
 
 ### Contributions welcome
 
 Fancy getting world-wide visibility and building up an eternal fame of an OSS contributor?
 
+* Use the [latest version](https://github.com/mockito/mockito/releases)! Hack and experiment.
+* Speak up at the [mailing list].
+* Report issues and suggest ideas on the [GitHub issue tracker](https://github.com/mockito/mockito/issues).
 * Help the [project site](https://github.com/mockito/mockito.github.io) look decent and match the quality of the library!
-* [Contribute](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md) a pull request! It is automatically released via state-of-art [continuous delivery automation](https://szczepiq.blogspot.com/2014_08_01_archive.html).
-* Use latest version! Hack and experiment. Speak up at the [mailing list]. Report [issues and new features](https://github.com/mockito/mockito/issues).
+* [Contribute](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md) a pull request! It is automatically released via state-of-art [continuous delivery automation](https://szczepiq.blogspot.com/2014_08_01_archive.html).
 
 <span id="forkongithub">
   <a href="{{ site.source_link }}" class="bg-green">


### PR DESCRIPTION
```
*  Fixes #47 : Reorganize for 3.x releases, reduce duplication
   
   Don't mention the current version in a section header. Badges should be
   sufficient, and they don't need manual update.
   
   Update repository links to the 3.x branch.
   
   Consolidate "Current version" and "Project status updates" sections into
   one "Project status" section. Avoid some duplication with "Contributions
   welcome".
   
   Update the twitter link, the logo image was broken. Use the "follow"
   button instead.
   
   Show "Still on Mockito 1.x?" in bold. Clarify the difference between 3.x
   and 2.x releases.
   
   Remove all forward looking statements about the next major release. They
   are hard to update by anyone but the core developers, and don't provide
   much value.
```