### PR TITLE
Updates Deprecated Gradle Configuration & adds 3.x import for java8

### DIFF
--- a/_posts/2000-01-10-how.md
+++ b/_posts/2000-01-10-how.md
@@ -12,7 +12,7 @@ With [Gradle](http://gradle.org) one can do:
 
 {% highlight Groovy %}
 repositories { jcenter() }
-dependencies { testCompile "org.mockito:mockito-core:2.+" }
+dependencies { testImplementation "org.mockito:mockito-core:3.+" }
 {% endhighlight %}
 
 Maven users can declare a [dependency on mockito-core](https://search.maven.org/search?q=g:org.mockito%20a:mockito-core).


### PR DESCRIPTION
Solves #52 
Earlier website showed testCompilation, which has been deprecated.
This is now replaced by testImplementation.

Also, way to import mockito 3.0 has been added.
