### PR TITLE
Remove references to bintray repository.

### DIFF
--- a/_posts/2000-01-10-how.md
+++ b/_posts/2000-01-10-how.md
@@ -16,16 +16,12 @@ dependencies { testImplementation "org.mockito:mockito-core:3.+" }
 {% endhighlight %}
 
 Maven users can declare a [dependency on mockito-core](https://search.maven.org/search?q=g:org.mockito%20a:mockito-core).
-Mockito is automatically published to [Bintray's jcenter](http://jcenter.bintray.com/org/mockito/mockito-core)
-and synced to the Maven Central Repository.
+Mockito publishes every change as a `-SNAPSHOT` version to a public [Sonatype repository](https://search.maven.org/artifact/org.mockito/mockito-core).
 
 Users doing manual dependency management can download the jars directly from 
-[Mockito's Bintray repository](https://bintray.com/mockito/maven/mockito-development/_latestVersion),
-under the Files tab.
+[Maven Central](https://repo1.maven.org/maven2/org/mockito/mockito-core/).
 
-Legacy builds with manual dependency management can use 1.* "mockito-all" distribution.
-It can be downloaded from Mockito's Bintray repository or Bintray's jcenter.
-"mockito-all" distribution has been discontinued in Mockito 2.*.
+Legacy builds with manual dependency management can use the [1.* "mockito-all" distribution](https://repo1.maven.org/maven2/org/mockito/mockito-all/). Said distribution has been discontinued in Mockito 2.\*.
 
 ## now you can verify interactions
 


### PR DESCRIPTION
Removed links and mentions of the dead bintray repo and replaced them with working equivalents from maven.org.