### PR TITLE
remove bintray batch from intro page.

### DIFF
--- a/_posts/2000-01-01-intro.md
+++ b/_posts/2000-01-01-intro.md
@@ -14,7 +14,6 @@ style: center
 [![Coverage Status](https://img.shields.io/codecov/c/github/mockito/mockito.svg)](https://codecov.io/github/mockito/mockito)
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/mockito/mockito/blob/master/LICENSE)
 
-[![Bintray](https://api.bintray.com/packages/mockito/maven/mockito-development/images/download.svg)](https://bintray.com/mockito/maven)
 [![Maven Central](https://img.shields.io/maven-central/v/org.mockito/mockito-core.svg)](https://search.maven.org/search?q=g:org.mockito%20AND%20a:mockito-core&core=gav)
 
 </div>
@@ -33,8 +32,7 @@ Updates are announced via [Twitter](https://twitter.com/mockitojava)
 and [mailing list] <img alt="Google Groups" src="https://groups.google.com/forum/favicon.ico" width="21" height="21">.
 
 Mockito downloads and instructions for setting up Maven, Gradle and other build systems are available from the
-[Central Repository](https://search.maven.org/artifact/org.mockito/mockito-core/) and
-[Bintray](https://bintray.com/mockito/maven/mockito/).
+[Central Repository](https://search.maven.org/artifact/org.mockito/mockito-core/).
 
 The documentation for all versions is available on
 [javadoc.io](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html)

--- a/_posts/2000-01-20-who.md
+++ b/_posts/2000-01-20-who.md
@@ -19,7 +19,7 @@ Friends who contributed to Mockito (apologize if I missed somebody):
 **Pascal Schumacher**, **Christian Schwartz**, **Igor Czechowski**, **Patric Fornasier**, **Jim Barritt**,
 **Felix Leipold**, **Liz Keogh**, **Dan North**, **Bartosz Bańkowski**, **David Wallace**.
 
-[Travis CI](https://travis-ci.org/mockito/mockito) and [Bintray](https://bintray.com/mockito/maven/mockito) are used to facilitate continuous delivery.
+[Travis CI](https://travis-ci.org/mockito/mockito) and Bintray are used to facilitate continuous delivery.
 Both tools are great. Thank you Travis, thank you Bintray!
 
 * Thanks to **Éric Lefevre-Ardant** for his long running and continuous support on the mailing-list

--- a/_posts/2000-01-20-who.md
+++ b/_posts/2000-01-20-who.md
@@ -19,8 +19,8 @@ Friends who contributed to Mockito (apologize if I missed somebody):
 **Pascal Schumacher**, **Christian Schwartz**, **Igor Czechowski**, **Patric Fornasier**, **Jim Barritt**,
 **Felix Leipold**, **Liz Keogh**, **Dan North**, **Bartosz Bańkowski**, **David Wallace**.
 
-[Travis CI](https://travis-ci.org/mockito/mockito) and Bintray are used to facilitate continuous delivery.
-Both tools are great. Thank you Travis, thank you Bintray!
+[GitHub actions](https://github.com/mockito/mockito/actions) and [Shipkit](http://shipkit.org) are used to facilitate continuous delivery.
+Both tools are great. Thank you GitHub, thank you Shipkit!
 
 * Thanks to **Éric Lefevre-Ardant** for his long running and continuous support on the mailing-list
 * Thanks to **Erik Ramfelt**, and **Steve Christou** for the Jenkins server that was used originally for CI.


### PR DESCRIPTION
I looked the (mockito site)[https://site.mockito.org/], and concerned about broken link of Bintray.
(Bintray service was sunset)