### PR TITLE
Replace jcenter() reference with Maven central

### DIFF
--- a/_posts/2000-01-10-how.md
+++ b/_posts/2000-01-10-how.md
@@ -11,7 +11,7 @@ on "mockito-core" library using your favorite build system.
 With [Gradle](http://gradle.org) one can do:
 
 {% highlight Groovy %}
-repositories { jcenter() }
+repositories { mavenCentral() }
 dependencies { testImplementation "org.mockito:mockito-core:3.+" }
 {% endhighlight %}
 


### PR DESCRIPTION
jcenter has been retired, therefore we should update the example