### PR TITLE
Fix java doc link

### DIFF
--- a/_posts/2000-01-01-intro.md
+++ b/_posts/2000-01-01-intro.md
@@ -33,7 +33,7 @@ Mockito downloads and instructions for setting up Maven, Gradle and other build 
 [Central Repository](https://search.maven.org/artifact/org.mockito/mockito-core/).
 
 The documentation for all versions is available on
-[javadoc.io](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html)
+[javadoc.io](https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html)
 (the site is updated within 24 hours of the latest release).
 
 **Still on Mockito 1.x?** See [what's new in Mockito 2](https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2)!


### PR DESCRIPTION
Fix the java doc link.
Reference issue: https://github.com/mockito/mockito/issues/3641